### PR TITLE
Arm aim helper

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -65,7 +65,9 @@ public class RobotContainer {
   private final JoystickButton m_feedOnlyButton = new JoystickButton(m_operatorController, XboxController.Button.kB.value);
   private final JoystickButton m_shootOnlyButton = new JoystickButton(m_operatorController, XboxController.Button.kA.value);
   private final JoystickButton m_backfeedButton = new JoystickButton(m_operatorController, 8);
-  private final POVButton m_shooterPrepButton  = new POVButton(m_operatorController, 0);
+  private final POVButton m_shooterPrepButton  = new POVButton(m_operatorController, 90);
+  private final POVButton m_armAutoAimAdjustUpButton = new POVButton(m_operatorController, 0);
+  private final POVButton m_armAutoAimAdjustDownButton = new POVButton(m_operatorController, 180);
   private final JoystickButton m_aimButton = new JoystickButton(m_driverController, XboxController.Button.kRightBumper.value);
   private final JoystickButton m_resetFieldRelativeButton = new JoystickButton(m_driverController, 7);
   private final JoystickButton m_precisionButton = new JoystickButton(m_driverController, XboxController.Button.kLeftBumper.value);
@@ -208,6 +210,14 @@ public class RobotContainer {
     }));
 
     m_aimButton.whileTrue(aimArmContinuous);
+
+    m_armAutoAimAdjustUpButton.onTrue(new InstantCommand(() -> {
+      m_arm.autoAimAdjustUp();
+    }));
+
+    m_armAutoAimAdjustDownButton.onTrue(new InstantCommand(() -> {
+      m_arm.autoAimAdjustDown();
+    }));
   }
 
   public void autonomousPeriodic() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -74,6 +74,7 @@ public class RobotContainer {
 
   private boolean m_wasAimPressedBefore = false;
   private RotationAimController m_rotationAimController = new RotationAimController(m_limelight);
+  private ArmAimHelper m_armAimHelper = new ArmAimHelper();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -290,5 +291,7 @@ public class RobotContainer {
     SmartDashboard.putBoolean("Have Note?", !m_intake.hasNote());
 
     SmartDashboard.putData(CommandScheduler.getInstance());
+
+    SmartDashboard.putNumber("Arm/Auto Aim Setpoint", m_armAimHelper.getArmSetpoint(m_limelight).getFirst());
   }
 }

--- a/src/main/java/frc/robot/XCaliper.java
+++ b/src/main/java/frc/robot/XCaliper.java
@@ -16,8 +16,12 @@ public class XCaliper extends TimedRobot {
   public void robotInit() {
     m_robotContainer = new RobotContainer();
 
-    for (int port = 5800; port <= 5807; port++) {
-      PortForwarder.add(port, "limelight.local", port);
+    for (int port = 5800; port <= 5801; port++) {
+      PortForwarder.add(port, "limelight-tags.local", port);
+    }
+
+    for (int port = 5802; port <= 5804; port++) {
+      PortForwarder.add(port, "limelight-notes.local", port);
     }
 
     // var camera = CameraServer.startAutomaticCapture();

--- a/src/main/java/frc/robot/commands/AimArm.java
+++ b/src/main/java/frc/robot/commands/AimArm.java
@@ -31,8 +31,7 @@ public class AimArm extends Command {
                 break;
             
             case SPEAKER:
-                var distance = limelight.getTargetDist();
-                arm.setAimpointSpeaker(distance);
+                arm.setAimpointSpeaker(limelight);
                 break;
 
             default:

--- a/src/main/java/frc/robot/commands/ShootSpeaker.java
+++ b/src/main/java/frc/robot/commands/ShootSpeaker.java
@@ -13,7 +13,7 @@ public class ShootSpeaker extends SequentialCommandGroup {
                 shooter::shoot,
                 shooter::stop,
                 shooter
-            ).withTimeout(1)
+            ).withTimeout(0.25)
         );
     }
 

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -23,7 +23,7 @@ public class Arm extends SubsystemBase {
     private SlewRateLimiter m_rateLimiter = new SlewRateLimiter(6);
 
     private final double MAX_SETPOINT = 45;
-    private final double AIM_ADJUSTMENT = 0.10;
+    private final double AIM_ADJUSTMENT = 0.05;
 
 
     public Arm() {

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -37,7 +37,6 @@ public class Arm extends SubsystemBase {
 
         m_armSetpointAdjustmentEntry = SmartDashboard.getEntry("Arm/Position Adjustment");
         m_armSetpointAdjustmentEntry.setDefaultDouble(0);
-        m_armSetpointAdjustmentEntry.setPersistent();
     }
 
     public void autoAimAdjustDown() {

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -64,8 +64,9 @@ public class Arm extends SubsystemBase {
                 MathUtil.clamp(m_positionController.getSetpoint() + rate, 0, MAX_SETPOINT));
     }
 
-    public void setAimpointSpeaker(double distance) {
-        var setpoint = m_armAimHelper.getArmSetpoint(distance) * (1 + m_armSetpointAdjustmentEntry.getDouble(0));
+    public void setAimpointSpeaker(Limelight limelight) {
+        var setpointAndSpeed = m_armAimHelper.getArmSetpoint(limelight);
+        var setpoint = setpointAndSpeed.getFirst() * (1 + m_armSetpointAdjustmentEntry.getDouble(0));
         setpoint = MathUtil.clamp(setpoint, 0, MAX_SETPOINT);
 
         m_positionController.setSetpoint(setpoint);

--- a/src/main/java/frc/robot/subsystems/ArmAimHelper.java
+++ b/src/main/java/frc/robot/subsystems/ArmAimHelper.java
@@ -3,57 +3,66 @@ package frc.robot.subsystems;
 import java.util.ArrayList;
 import java.util.Comparator;
 
+import edu.wpi.first.math.Pair;
+
 public class ArmAimHelper {
-    // list of observed distances and setpoints (distance isn't true distance, because my limelightY->distance formula is bad).
+    // list of observed targetYs and setpoints
     // this lets us collect different distances, so we aren't stuck with a straight line
     private final ArrayList<ArmSetpoint> m_armSetpoints = new ArrayList<ArmSetpoint>() {
         {
-            add(new ArmSetpoint(0, 0));
-            add(new ArmSetpoint(4, 15));
+            add(new ArmSetpoint(0, 0, 1));
+            add(new ArmSetpoint(-16.7, 12.78, 1)); // 1m
+            add(new ArmSetpoint(-26, 18.66, 1)); // 2m
+            add(new ArmSetpoint(-30.18, 20.35, 1)); // 3m
+            add(new ArmSetpoint(-33.14, 21, 1)); // 4m
         }
     };
 
-    public double getArmSetpoint(double distance) {
+    public Pair<Double, Double> getArmSetpoint(Limelight limelight) {
+        var targetY = limelight.getTargetY();
         var setpoints = m_armSetpoints.stream()
-                .sorted(new ArmSetpointComparator(distance)) // sort by which setpoints are closer to the distance we a looking for 
+                .sorted(new ArmSetpointComparator(targetY)) // sort by which setpoints are closer to the distance we a looking for 
                 .limit(2) // grab just the first two
                 .toList();
         
         var setpoint1 = setpoints.get(0);
         var setpoint2 = setpoints.get(1);
 
-        // our distance is what ratio between these two setpoints?
-        var distRatio = (distance - setpoint1.Distance) / (setpoint2.Distance - setpoint1.Distance);
+        // our targetY is what ratio between these two setpoints?
+        var distRatio = (targetY - setpoint1.TargetY) / (setpoint2.TargetY - setpoint1.TargetY);
 
         // apply that ratio to the setpoints range
         var setpoint = setpoint1.Setpoint + ((setpoint2.Setpoint - setpoint1.Setpoint) * distRatio);
+        var speed = setpoint1.Speed + ((setpoint2.Speed - setpoint1.Speed) * distRatio);
 
-        return setpoint;
+        return new Pair<Double,Double>(setpoint, speed);
     }
 
     // tracks a distance/setpoint pair
     private class ArmSetpoint {
-        public ArmSetpoint(double distance, double setpoint) {
-            Distance = distance;
+        public ArmSetpoint(double targetY, double setpoint, double speed) {
+            TargetY = targetY;
             Setpoint = setpoint;
+            Speed = speed;
         }
 
-        public double Distance;
+        public double TargetY;
         public double Setpoint;
+        public double Speed;
     }
 
     // compares two ArmSetpoint by how close it is to our target distance
     private class ArmSetpointComparator implements Comparator<ArmSetpoint> {
-        private double distance;
+        private double targetY;
 
-        public ArmSetpointComparator(double targetDistance) {
-            this.distance = targetDistance;
+        public ArmSetpointComparator(double targetY) {
+            this.targetY = targetY;
         }
 
         @Override
         public int compare(ArmSetpoint a, ArmSetpoint b) {
-            var aProximity = Math.abs(a.Distance - distance);
-            var bProximity = Math.abs(b.Distance - distance);
+            var aProximity = Math.abs(a.TargetY - targetY);
+            var bProximity = Math.abs(b.TargetY - targetY);
             return Double.compare(aProximity, bProximity);
         }
 

--- a/src/main/java/frc/robot/subsystems/ArmAimHelper.java
+++ b/src/main/java/frc/robot/subsystems/ArmAimHelper.java
@@ -1,0 +1,61 @@
+package frc.robot.subsystems;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+
+public class ArmAimHelper {
+    // list of observed distances and setpoints (distance isn't true distance, because my limelightY->distance formula is bad).
+    // this lets us collect different distances, so we aren't stuck with a straight line
+    private final ArrayList<ArmSetpoint> m_armSetpoints = new ArrayList<ArmSetpoint>() {
+        {
+            add(new ArmSetpoint(0, 0));
+            add(new ArmSetpoint(4, 15));
+        }
+    };
+
+    public double getArmSetpoint(double distance) {
+        var setpoints = m_armSetpoints.stream()
+                .sorted(new ArmSetpointComparator(distance)) // sort by which setpoints are closer to the distance we a looking for 
+                .limit(2) // grab just the first two
+                .toList();
+        
+        var setpoint1 = setpoints.get(0);
+        var setpoint2 = setpoints.get(1);
+
+        // our distance is what ratio between these two setpoints?
+        var distRatio = (distance - setpoint1.Distance) / (setpoint2.Distance - setpoint1.Distance);
+
+        // apply that ratio to the setpoints range
+        var setpoint = setpoint1.Setpoint + ((setpoint2.Setpoint - setpoint1.Setpoint) * distRatio);
+
+        return setpoint;
+    }
+
+    // tracks a distance/setpoint pair
+    private class ArmSetpoint {
+        public ArmSetpoint(double distance, double setpoint) {
+            Distance = distance;
+            Setpoint = setpoint;
+        }
+
+        public double Distance;
+        public double Setpoint;
+    }
+
+    // compares two ArmSetpoint by how close it is to our target distance
+    private class ArmSetpointComparator implements Comparator<ArmSetpoint> {
+        private double distance;
+
+        public ArmSetpointComparator(double targetDistance) {
+            this.distance = targetDistance;
+        }
+
+        @Override
+        public int compare(ArmSetpoint a, ArmSetpoint b) {
+            var aProximity = Math.abs(a.Distance - distance);
+            var bProximity = Math.abs(b.Distance - distance);
+            return Double.compare(aProximity, bProximity);
+        }
+
+    }
+}

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -9,7 +9,7 @@ import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
 public class Limelight extends SubsystemBase{
-    NetworkTable table = NetworkTableInstance.getDefault().getTable("limelight");
+    NetworkTable table = NetworkTableInstance.getDefault().getTable("limelight-tags");
     NetworkTableEntry tid = table.getEntry("tid");
     NetworkTableEntry tx = table.getEntry("tx");
     NetworkTableEntry ty = table.getEntry("ty");
@@ -24,11 +24,13 @@ public class Limelight extends SubsystemBase{
         return ty.getDouble(0);
     }
 
-    public double getTargetDistBlended() {
+    // private. Not dependable yet.
+    private double getTargetDistBlended() {
         return (getTargetY() + getTargetA()) / 2;
     }
 
-    public double getTargetDist() {
+    // private. Not dependable yet.
+    private double getTargetDist() {
         var y = getTargetY();
         if (y == -1) return 0;
 

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -97,7 +97,7 @@ public class Shooter extends SubsystemBase {
 
   @Override
   public void periodic() {
-    m_shootMotor.set(m_shooterRateLimiter.calculate(m_shooterSpeed));
+    m_shootMotor.setVoltage(m_shooterRateLimiter.calculate(m_shooterSpeed) * 12);
     m_feedMotor.set(m_feedSpeed);
     SmartDashboard.putNumber("Shooter/Speed", m_shootMotor.getVelocity().getValueAsDouble());
     SmartDashboard.putNumber("Shooter/Feed", m_feedMotor.getEncoder().getVelocity());


### PR DESCRIPTION
Summary
- It breaks the distance -> arm setpoint algorithm into it's own ArmAimHelper class.
- ArmAimHelper is setup with a table of distance/setpoint pairs, and when it's asked to provide a setpoint for a certain distance, it compares the distance to the table it has and blends the setpoints of the two closest entries. There are only 2 entries right now - but the idea is that we can add more, and account for the non-linearity of our aiming solution.
- Changes the operator's "shooter prep" button to the POV right, to make room for:
- Operator's POV Up and Down buttons adjust an offset to the arm's aiming formula - so if they find in-game that they are consistently shooting high or low, the operator can adjust during the game.
- NOTE:  All needs to be tested, of course. :-)